### PR TITLE
Fix initializing two or more services on RFmx.

### DIFF
--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -1161,7 +1161,7 @@ namespace nidaqmx_grpc {
     try {
       auto task_grpc_session = request->task();
       TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
-      session_repository_->remove_session(task);
+      session_repository_->remove_session(task_grpc_session.id(), task_grpc_session.name());
       auto status = library_->ClearTask(task);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -1006,7 +1006,7 @@ namespace nidcpower_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi);
+      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -282,7 +282,7 @@ namespace nidigitalpattern_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi);
+      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -285,7 +285,7 @@ namespace nidmm_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi);
+      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -1926,7 +1926,7 @@ namespace nifake_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi);
+      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->close(vi);
       response->set_status(status);
       return ::grpc::Status::OK;
@@ -1947,7 +1947,7 @@ namespace nifake_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 action = request->action();
-      session_repository_->remove_session(vi);
+      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->CloseExtCal(vi, action);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -54,7 +54,7 @@ namespace nifake_non_ivi_grpc {
     try {
       auto handle_grpc_session = request->handle();
       FakeHandle handle = session_repository_->access_session(handle_grpc_session.id(), handle_grpc_session.name());
-      session_repository_->remove_session(handle);
+      session_repository_->remove_session(handle_grpc_session.id(), handle_grpc_session.name());
       auto status = library_->Close(handle);
       response->set_status(status);
       return ::grpc::Status::OK;
@@ -75,7 +75,7 @@ namespace nifake_non_ivi_grpc {
       auto handle_grpc_session = request->handle();
       FakeHandle handle = session_repository_->access_session(handle_grpc_session.id(), handle_grpc_session.name());
 
-      auto initiating_session_id = session_repository_->resolve_session_id(handle);
+      auto initiating_session_id = session_repository_->access_session_id(handle_grpc_session.id(), handle_grpc_session.name());
       auto init_lambda = [&] () {
         FakeCrossDriverHandle cross_driver_session;
         int status = library_->GetCrossDriverSession(handle, &cross_driver_session);

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -484,7 +484,7 @@ namespace nifgen_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi);
+      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -550,7 +550,7 @@ namespace nirfmxinstr_grpc {
       auto instrument_grpc_session = request->instrument();
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       int32 force_destroy = request->force_destroy();
-      session_repository_->remove_session(instrument);
+      session_repository_->remove_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->Close(instrument, force_destroy);
       response->set_status(status);
       return ::grpc::Status::OK;
@@ -1532,7 +1532,7 @@ namespace nirfmxinstr_grpc {
       auto instrument_grpc_session = request->instrument();
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
 
-      auto initiating_session_id = session_repository_->resolve_session_id(instrument);
+      auto initiating_session_id = session_repository_->access_session_id(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto init_lambda = [&] () {
         ViSession ni_rfsa_session;
         int status = library_->GetNIRFSASession(instrument, &ni_rfsa_session);

--- a/generated/nirfmxnr/nirfmxnr_service.cpp
+++ b/generated/nirfmxnr/nirfmxnr_service.cpp
@@ -66,7 +66,7 @@ namespace nirfmxnr_grpc {
         }
       }
 
-      session_repository_->remove_session(instrument_handle);
+      session_repository_->remove_session(instrument_handle_grpc_session.id(), instrument_handle_grpc_session.name());
       auto status = library_->Close(instrument_handle, force_destroy);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/generated/nirfmxspecan/nirfmxspecan_service.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_service.cpp
@@ -3805,7 +3805,7 @@ namespace nirfmxspecan_grpc {
       auto instrument_grpc_session = request->instrument();
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       int32 force_destroy = request->force_destroy();
-      session_repository_->remove_session(instrument);
+      session_repository_->remove_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->Close(instrument, force_destroy);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -134,7 +134,7 @@ namespace nirfsa_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi);
+      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/generated/nirfsg/nirfsg_service.cpp
+++ b/generated/nirfsg/nirfsg_service.cpp
@@ -447,7 +447,7 @@ namespace nirfsg_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi);
+      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -565,7 +565,7 @@ namespace niscope_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi);
+      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -262,7 +262,7 @@ namespace niswitch_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi);
+      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -85,7 +85,7 @@ namespace nisync_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi);
+      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -521,6 +521,14 @@ def get_param_with_name(parameters: List[dict], name: str) -> dict:
     )
     return next(matched_params)
 
+def get_first_session_param(parameters: List[dict]) -> dict:
+    matched_params = (
+        p
+        for p in parameters
+        if p.get('grpc_type', None) == 'nidevice_grpc.Session'
+    )
+    return next(matched_params)
+
 
 def get_ivi_dance_with_a_twist_params(parameters):
     array_param = next(

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -48,10 +48,11 @@ ${initialize_output_params(output_parameters_to_initialize)}\
   cross_driver_dep = service_helpers.get_cross_driver_session_dependency(session_output_param)
   session_output_var_name = common_helpers.get_cpp_local_name(session_output_param)
   initiating_driver_input_var_name = common_helpers.get_cpp_local_name(initiating_driver_input_param)
+  initiating_driver_c_name = f'{initiating_driver_input_var_name}_grpc_session'
 %>\
 ${initialize_input_params(function_name, parameters)}
 ${initialize_output_params(output_parameters_to_initialize)}\
-      auto initiating_session_id = session_repository_->resolve_session_id(${initiating_driver_input_var_name});
+      auto initiating_session_id = session_repository_->access_session_id(${initiating_driver_c_name}.id(), ${initiating_driver_c_name}.name());
       auto init_lambda = [&] () {
         ${cross_driver_dep.resource_handle_type} ${session_output_var_name};
         int status = library_->${function_name}(${service_helpers.create_args(parameters)});
@@ -242,7 +243,11 @@ ${set_response_values(output_parameters=output_parameters)}\
 ${initialize_input_params(function_name, parameters)}\
 ${initialize_output_params(output_parameters)}\
 % if function_name == config['close_function'] or service_helpers.is_custom_close_method(function_data):
-      session_repository_->remove_session(${service_helpers.create_args(parameters[:1])});
+<%
+  session_param = common_helpers.get_first_session_param(parameters)
+  session_param_name = f'{common_helpers.get_cpp_local_name(session_param)}_grpc_session'
+%>\
+      session_repository_->remove_session(${session_param_name}.id(), ${session_param_name}.name());
 % endif
       auto status = library_->${function_name}(${service_helpers.create_args(parameters)});
       response->set_status(status);

--- a/source/tests/system/nirfmxnr_session_tests.cpp
+++ b/source/tests/system/nirfmxnr_session_tests.cpp
@@ -111,7 +111,6 @@ TEST_F(NiRFmxNRSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
 
 TEST_F(NiRFmxNRSessionTest, TwoInitializedSessionsOnSameDevice_CloseSessions_ClosesDriverSessions)
 {
-  GTEST_SKIP() << "Initializing two sessions on same device is currently broken. Planning to fix with AB#1792683";
   rfmxnr::InitializeResponse init_response_one, init_response_two;
   ::grpc::Status status_one = call_initialize(kRFmxNRTestRsrc, kRFmxNROptionsString, kRFmxNRTestSessionOne, &init_response_one);
   ::grpc::Status status_two = call_initialize(kRFmxNRTestRsrc, kRFmxNROptionsString, kRFmxNRTestSessionTwo, &init_response_two);

--- a/source/tests/unit/session_resource_repository_tests.cpp
+++ b/source/tests/unit/session_resource_repository_tests.cpp
@@ -86,7 +86,7 @@ TEST(SessionResourceRepositoryTests, SessionResource_RemoveFromResourceRepositor
 
   // Remove from the SessionResourceRepository and ensure that it removes from the
   // SessionRepository and SessionResourceRepository.
-  resource_repository.remove_session(kResourceHandle);
+  resource_repository.remove_session(session_id, "");
 
   EXPECT_EQ(
       kNoSession,


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes issue with session_resource_repository in relation to RFmx sessions.

- Our session repository assumes 1 driver session maps to 1 grpc_session (which is stored in our session repository)
- RFmx breaks this assumption. Specifically when a second initialize is called on the same device it will overwrite the previous key/value pair in the `reverse_map_` with the same handle but new session_id.
- Then when you try to close the sessions you get an error because it is accessing the session id's through the `reverse_map_` which isn't accurate.

### Why should this Pull Request be merged?

Currently, initializing two or more sessions on the same device in an RFmx service causes problems with session management.

### What testing has been done?

System level test for RFmx NR passes (Two sessions initialized on same device -> Close -> Close succeeds on both calls).
TODO: Write equivalent tests for Bluetooth and WLAN session tests.

All other Unit, Integration, and System level tests pass locally (except a couple pre-existing System level test failures).
